### PR TITLE
Update queries to support multiple servers

### DIFF
--- a/comms/search.js
+++ b/comms/search.js
@@ -65,7 +65,7 @@ module.exports = {
 
             con.connect(error => {
                 if (error) throw error;
-                con.query("SELECT m.attacker AS 'Steam_ID', `Name`, `Wounds`,`Kills`,`Deaths`,`Kills`/`Deaths` AS `K/D`,`Revives`,m.id AS 'ID' FROM `PlayerWounded` m LEFT JOIN ( SELECT attacker, COUNT(*) AS `Wounds` FROM `PlayerWounded` WHERE server = 1 GROUP BY attacker ORDER BY time ASC) w ON w.attacker = m.attacker LEFT JOIN (SELECT attacker, COUNT(*) AS `Kills` FROM `PlayerDied` WHERE server = 1  GROUP BY attacker) k ON k.attacker = m.attacker LEFT JOIN ( SELECT victim, COUNT(*) AS `Deaths` FROM `PlayerDied` WHERE server = 1 GROUP BY victim) d ON d.victim = m.attacker LEFT JOIN (SELECT steamID, lastName AS `Name` FROM `SteamUser`) s ON s.steamID = m.attacker LEFT JOIN ( SELECT reviver, COUNT(*) AS `Revives` FROM `PlayerRevived` WHERE server = 1 GROUP BY reviver ) r ON r.reviver = m.attacker WHERE steamID = '" + a + "' AND server = 1  GROUP BY m.attacker HAVING `K/D` IS NOT NULL ORDER BY `K/D` DESC, time DESC", function (error, result, fields) {
+                con.query("SELECT m.attacker AS 'Steam_ID', `Name`, `Wounds`,`Kills`,`Deaths`,`Kills`/`Deaths` AS `K/D`,`Revives`,m.id AS 'ID' FROM `PlayerWounded` m LEFT JOIN ( SELECT attacker, COUNT(*) AS `Wounds` FROM `PlayerWounded` GROUP BY attacker ORDER BY time ASC) w ON w.attacker = m.attacker LEFT JOIN (SELECT attacker, COUNT(*) AS `Kills` FROM `PlayerDied` GROUP BY attacker) k ON k.attacker = m.attacker LEFT JOIN ( SELECT victim, COUNT(*) AS `Deaths` FROM `PlayerDied` GROUP BY victim) d ON d.victim = m.attacker LEFT JOIN (SELECT steamID, lastName AS `Name` FROM `SteamUser`) s ON s.steamID = m.attacker LEFT JOIN ( SELECT reviver, COUNT(*) AS `Revives` FROM `PlayerRevived` GROUP BY reviver ) r ON r.reviver = m.attacker WHERE steamID = '" + a + "' GROUP BY m.attacker HAVING `K/D` IS NOT NULL ORDER BY `K/D` DESC, time DESC", function (error, result, fields) {
                     if (error) {
                         let dbConnectionEmbed = new MessageEmbed()
                             .setTitle(`Ooops! Wrong Syntax`)
@@ -161,7 +161,7 @@ module.exports = {
                                 `\u200B`, `\u200B`
                             );
 
-                            con.query("SELECT attacker, weapon, COUNT(weapon) FROM `PlayerDied` WHERE server = 1 AND attacker = '" + a + "' GROUP BY weapon  ORDER BY COUNT(weapon) DESC;", function (error1, result1, fields1) {
+                            con.query("SELECT attacker, weapon, COUNT(weapon) FROM `PlayerDied` WHERE attacker = '" + a + "' GROUP BY weapon ORDER BY COUNT(weapon) DESC;", function (error1, result1, fields1) {
                                 if (error1) throw error1;
 
                                 searchEmbed.addField(
@@ -171,7 +171,7 @@ module.exports = {
                                 );
                             });
 
-                            con.query("SELECT attacker, weapon, COUNT(weapon) FROM `PlayerWounded` WHERE server = 1 AND attacker = '" + a + "' GROUP BY weapon  ORDER BY COUNT(weapon) DESC;", function (error2, result2, fields2) {
+                            con.query("SELECT attacker, weapon, COUNT(weapon) FROM `PlayerWounded` WHERE attacker = '" + a + "' GROUP BY weapon  ORDER BY COUNT(weapon) DESC;", function (error2, result2, fields2) {
                                 if (error2) throw error2;
 
                                 searchEmbed.addField(


### PR DESCRIPTION
I changed around the queries in the MySQL statements to not check for server = 1. This should allow the queries to iterate over X number of servers if the community has more than one.